### PR TITLE
fix(ios): dismiss ios recorder properly

### DIFF
--- a/src/ios/CDVCapture.m
+++ b/src/ios/CDVCapture.m
@@ -685,7 +685,7 @@ NSNumber *globalHeight;
 
 @end
 
-@interface CDVAudioRecorderViewController () {
+@interface CDVAudioRecorderViewController () <UIAdaptivePresentationControllerDelegate> {
     UIStatusBarStyle _previousStatusBarStyle;
 }
 @end
@@ -733,6 +733,9 @@ NSNumber *globalHeight;
 	if ([self respondsToSelector:@selector(edgesForExtendedLayout)]) {
         self.edgesForExtendedLayout = UIRectEdgeNone;
     }
+
+   // Add delegate to catch the dismiss event
+    self.navigationController.presentationController.delegate = self;
 
     // create view and display
     CGRect viewRect = [[UIScreen mainScreen] applicationFrame];
@@ -991,6 +994,10 @@ NSNumber *globalHeight;
     if (IsAtLeastiOSVersion(@"7.0")) {
         [[UIApplication sharedApplication] setStatusBarStyle:_previousStatusBarStyle];
     }
+}
+
+- (void)presentationControllerDidDismiss:(UIPresentationController *)presentationController {
+    [self dismissAudioView:nil];
 }
 
 - (void)updateTime


### PR DESCRIPTION
IOS swipe down dismiss prevent recorder from being open for second time

1. Original commit - https://github.com/apache/cordova-plugin-media-capture/pull/186/commits/48d90a675ee5a19508bdca8e7380b442ae679ea9